### PR TITLE
Accessibility improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
 
 <head>
   <meta charset="utf-8">
@@ -21,11 +21,11 @@
   <div class="content">
     <div class="header">
       <div class="container">
-        <h2 class="title">ParteiDuell</h2>
+        <h1 class="title">ParteiDuell</h1>
       </div>
     </div>
 
-    <div id="root" class="container"></div>
+    <div id="root" class="container" role="main"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
@@ -37,15 +37,13 @@
       To create a production bundle, use `npm run build`.
     -->
   </div>
-  <div class="footer">
-    <div>
-      Mit ❤ beim JHFFM19 erstellt.
-    </div>
+  <footer class="footer" role="contentinfo">
+    <div>Mit ❤ bei JHFFM19 erstellt.</div>
     <a href="https://www.github.com/jugendhackt/parteiduell-frontend">
-      <img src="/github.png" alt="Github">
+      <img role="link" aria-label="GitHub" src="/github.png" alt="GitHub">
     </a>
-    <img src="/logo.png" alt="Logo">
-  </div>
+    <img src="/logo.png" alt="Logo" aria-hidden="true">
+  </footer>
 </body>
 
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -159,14 +159,6 @@ button {
   border: 2px rgb(0, 102, 255) solid;
 }
 
-.quote::before {
-  content: '”';
-}
-
-.quote::after {
-  content: ' ”';
-}
-
 .quote {
   font-style: italic;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -166,11 +166,6 @@ button {
     border: 2px rgb(0, 102, 255) solid;
 }
 
-
-.quote::before {
-    content: '”';
-}
-
 .quote {
     font-style: italic;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -137,7 +137,7 @@ class Fragen extends Component {
       if (correct) {
         return (
           <div>
-            <p id="answer">Richtig!</p>
+            <p autoFocus={true} id="answer">Richtig!</p>
             <Confetti
               width={this.props.windowWidth}
               height={this.props.windowHeight} //adjusts window size automatically
@@ -155,11 +155,11 @@ class Fragen extends Component {
       } else {
         return (
           <div>
-            <h2>Falsch, diese Aussage war von {items[0].answer}</h2>
-            <h3>Die Partei "{selected}" hat folgendes Statement abgegeben:</h3>
+            <h2 autoFocus={true}>Falsch, diese Aussage war von {items[0].answer}</h2>
+            <p>Die Partei "{selected}" hat folgendes Statement abgegeben:</p>
             <p class="quote">{items[0].possibleAnswers[selected]}</p>
             <label class="next">
-              <button onClick={this.handleNext.bind(this)}></button>
+              <button role={"button"} onClick={this.handleNext.bind(this)}></button>
               Nächste Frage
             </label>
           </div >
@@ -180,14 +180,14 @@ class Fragen extends Component {
             item => (
               <div>
                 <p class="these"> {item.these} </p>
-                <p class="statement quote">{item.statement}</p>
+                <p class="statement quote">{'"'+item.statement+'"'}</p>
                 <div class="source">{item.source} - {item.context}</div>
                 <div id="options" className={[selected ? "selected" : "", joystick ? "joystick" : ""].join(" ")}>
                   {parties.map(
                     partei => (
                       <label class="logos">
-                        <img src={this.getImage(partei)} alt={partei} className={(partei === this.state.items[0].answer) ? "right" : "wrong"} />
-                        <button onClick={this.compare(partei)}> {partei} </button>
+			                  <img role={"button"} src={this.getImage(partei)} aria-label={partei} alt={partei} className={(partei === this.state.items[0].answer) ? "right" : "wrong"} />
+                        <button onClick={this.compare(partei)}></button>
                       </label>
                     )
                   )}


### PR DESCRIPTION
Done:

* Ignore logo for screenreader users
* Items that are not actually images advertise their true role to the accessibility tree
* Fix that quotation marks in the quote are read aloud separately by screenreaders

To do:

* Automatically move focus to the result when it appears